### PR TITLE
Fix serialising of one or two digit millisecond values

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -771,7 +771,7 @@
 
   var WebVTTSerializer = function() {
     function serializeTimestamp(seconds) {
-      const ms = ("" + (seconds - Math.floor(seconds)).toFixed(3)*1000).padEnd(3, "0");
+      const ms = ("00" + (seconds - Math.floor(seconds)).toFixed(3)*1000).slice(-3);
       let h = 0, m = 0, s = 0;
       if (seconds >= 3600) {
         h = Math.floor(seconds/3600);


### PR DESCRIPTION
There's a bug in `serializeTimestamp` that assumes that millisecond values should always be end-padded with zeros up to three digits. This isn't true when milliseconds is less than 100, since these need to be start-padded with at least one zero to maintain their meaning.

Rather than try to find a clever solution, I opted for the old prepend-zeroes-and-slice trick.

Consider the following cue:

```
00:53.920 --> 00:59.040
Just some random text
```

This will currently be incorrectly serialised as :
```
00:53.920 --> 00:59.400
Just some random text
```