### PR TITLE
Update license identifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   ],
   "author": "Anne van Kesteren <annevk@annevk.nl>",
   "contributors": [],
-  "license": "CC0",
+  "license": "CC0-1.0",
   "bugs": {
     "url": "https://github.com/w3c/webvtt.js/issues"
   },


### PR DESCRIPTION
`CC0` is not a valid [SPDX](https://spdx.org/licenses/) identifier. Updated to `CC0-1.0`