### PR TITLE
Zero-pad hours to two digits when they exist but are less than ten

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -802,7 +802,7 @@
       }
       m = Math.floor((seconds - 3600*h) / 60);
       s = Math.floor(seconds - 3600*h - 60*m);
-      return (h ? h + ":" : "") + ("" + m).padStart(2, "0") + ":" + ("" + s).padStart(2, "0") + "." + ms;
+      return (h ? ("" + h).padStart(2, "0") + ":" : "") + ("" + m).padStart(2, "0") + ":" + ("" + s).padStart(2, "0") + "." + ms;
     }
     function serializeCueSettings(cue) {
       var result = ""


### PR DESCRIPTION
https://www.w3.org/TR/webvtt1/#webvtt-timestamp states that hours should be at least two digits when present.

Ensure the serialiser zero-pads the hours when less than 10.